### PR TITLE
dynamo db event trigger 추가

### DIFF
--- a/src/lib/builder.js
+++ b/src/lib/builder.js
@@ -1082,6 +1082,12 @@ async function printServerlessFunction(templateFile, apiSpecList, stage, version
                                     }
                                 })
                             }
+                            //dynamo db에 의해 트리거 되는 함수
+                            else if (element.type == "ddb") {
+                                funcObject["events"].push({
+                                    stream: { type: "dynamodb", arn: { "Fn::GetAtt": [element.table, "StreamArn"] }, filterPatterns: element.filterPatterns }
+                                })
+                            }
                             //어느 이벤트에도 트리거되지 않는 함수
                             else if (item.type == "pure") { }
                             //별도의 명시가 없다면 pure


### PR DESCRIPTION
ddb event를 트리거로 사용할 수 있도록 추가했습니다.
```
type: ddb
table: (ddb table 이름)
filterPattern: (filter 필요한 경우에만 입력)
```
event 입력 형식은 위와 같습니다.